### PR TITLE
Add donation note encouraging support for Dharma Seed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,17 @@
       <div id="search-results"></div>
       <button id="load-more" hidden>Load more</button>
     </div>
+
+    <div id="donation-note">
+      <p>
+        This player is an independent wrapper around
+        <a href="https://www.dharmaseed.org" target="_blank" rel="noopener">Dharma Seed</a>,
+        a nonprofit that does the real work of recording, hosting, and curating thousands of
+        meditation talks. If you find these teachings valuable, please consider
+        <a href="https://www.dharmaseed.org/about/donation" target="_blank" rel="noopener">making a donation</a>
+        to help them keep the dharma freely available to all.
+      </p>
+    </div>
   </main>
 
   <div id="queue-toggle">

--- a/public/styles.css
+++ b/public/styles.css
@@ -493,6 +493,27 @@ header h1 {
   white-space: nowrap;
 }
 
+/* Donation note */
+#donation-note {
+  margin: 16px 16px 0;
+  padding: 12px 16px;
+  background: #f8faf6;
+  border: 1px solid #d4e5ca;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+#donation-note a {
+  color: #2d5016;
+  font-weight: 500;
+}
+
+#donation-note a:hover {
+  color: #3d6b20;
+}
+
 /* Loading state */
 .loading {
   text-align: center;


### PR DESCRIPTION
This app is a wrapper around dharmaseed.org — they do the heavy lifting
of recording, hosting, and curating talks. The note links to their
donation page so users can support keeping the dharma freely available.