### PR TITLE
Add playlist feature with TDD

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,12 @@
 
   <div id="queue-panel" class="hidden">
     <div id="queue-header">
-      <h2>Queue</h2>
+      <div id="playlist-controls">
+        <select id="playlist-select"></select>
+        <button id="new-playlist-btn" title="New playlist">+</button>
+        <button id="rename-playlist-btn" title="Rename playlist" hidden>Rename</button>
+        <button id="delete-playlist-btn" title="Delete playlist" hidden>Delete</button>
+      </div>
       <button id="queue-close">&times;</button>
     </div>
     <div id="queue-list"></div>

--- a/public/playlist.js
+++ b/public/playlist.js
@@ -1,0 +1,136 @@
+const PLAYLISTS_KEY = "playlists";
+const ACTIVE_KEY = "active_playlist_id";
+const OLD_QUEUE_KEY = "talk_queue";
+const DEFAULT_ID = "queue";
+
+/**
+ * Creates a playlist store backed by the given storage (localStorage or mock).
+ * Pure data layer — no DOM dependencies.
+ */
+export function createPlaylistStore(storage) {
+  let playlists = load();
+  let activeId = storage.getItem(ACTIVE_KEY) || DEFAULT_ID;
+
+  // Validate active points to existing playlist
+  if (!playlists.some((p) => p.id === activeId)) {
+    activeId = DEFAULT_ID;
+  }
+
+  function load() {
+    const raw = storage.getItem(PLAYLISTS_KEY);
+    if (raw) {
+      try {
+        return JSON.parse(raw);
+      } catch {
+        // fall through to migration / default
+      }
+    }
+
+    // Attempt migration from old talk_queue format
+    const oldRaw = storage.getItem(OLD_QUEUE_KEY);
+    if (oldRaw) {
+      try {
+        const oldTalks = JSON.parse(oldRaw);
+        if (Array.isArray(oldTalks)) {
+          const migrated = [{ id: DEFAULT_ID, name: "Queue", talks: oldTalks }];
+          storage.setItem(PLAYLISTS_KEY, JSON.stringify(migrated));
+          storage.removeItem(OLD_QUEUE_KEY);
+          return migrated;
+        }
+      } catch {
+        // ignore bad data
+      }
+    }
+
+    // Fresh start
+    const fresh = [{ id: DEFAULT_ID, name: "Queue", talks: [] }];
+    storage.setItem(PLAYLISTS_KEY, JSON.stringify(fresh));
+    return fresh;
+  }
+
+  function save() {
+    storage.setItem(PLAYLISTS_KEY, JSON.stringify(playlists));
+    storage.setItem(ACTIVE_KEY, activeId);
+  }
+
+  function findPlaylist(id) {
+    return playlists.find((p) => p.id === id) || null;
+  }
+
+  return {
+    getPlaylists() {
+      return [...playlists];
+    },
+
+    getPlaylist(id) {
+      const pl = findPlaylist(id);
+      return pl ? { ...pl, talks: [...pl.talks] } : null;
+    },
+
+    getActivePlaylistId() {
+      return activeId;
+    },
+
+    setActivePlaylist(id) {
+      if (!findPlaylist(id)) return;
+      activeId = id;
+      save();
+    },
+
+    addTalk(playlistId, talk) {
+      const pl = findPlaylist(playlistId);
+      if (!pl) return;
+      if (pl.talks.some((t) => t.id === talk.id)) return;
+      pl.talks.push(talk);
+      save();
+    },
+
+    removeTalk(playlistId, talkId) {
+      const pl = findPlaylist(playlistId);
+      if (!pl) return;
+      pl.talks = pl.talks.filter((t) => t.id !== talkId);
+      save();
+    },
+
+    next() {
+      const pl = findPlaylist(activeId);
+      if (!pl || pl.talks.length === 0) return null;
+      const talk = pl.talks.shift();
+      save();
+      return talk;
+    },
+
+    getAll(playlistId) {
+      const pl = findPlaylist(playlistId);
+      return pl ? [...pl.talks] : [];
+    },
+
+    findById(playlistId, talkId) {
+      const pl = findPlaylist(playlistId);
+      if (!pl) return null;
+      return pl.talks.find((t) => t.id === talkId) || null;
+    },
+
+    createPlaylist(name) {
+      const id = crypto.randomUUID();
+      playlists.push({ id, name, talks: [] });
+      save();
+      return id;
+    },
+
+    renamePlaylist(id, name) {
+      if (id === DEFAULT_ID) return;
+      const pl = findPlaylist(id);
+      if (!pl) return;
+      pl.name = name;
+      save();
+    },
+
+    deletePlaylist(id) {
+      if (id === DEFAULT_ID) return;
+      playlists = playlists.filter((p) => p.id !== id);
+      if (activeId === id) activeId = DEFAULT_ID;
+      save();
+    },
+  };
+}

--- a/public/queue.js
+++ b/public/queue.js
@@ -1,73 +1,135 @@
-const STORAGE_KEY = "talk_queue";
-let talks = loadQueue();
+import { createPlaylistStore } from "./playlist.js";
+
+const store = createPlaylistStore(localStorage);
 
 const listEl = document.getElementById("queue-list");
 const countEl = document.getElementById("queue-count");
 const panel = document.getElementById("queue-panel");
 const toggleBtn = document.getElementById("queue-btn");
 const closeBtn = document.getElementById("queue-close");
+const playlistSelect = document.getElementById("playlist-select");
+const newPlaylistBtn = document.getElementById("new-playlist-btn");
+const deletePlaylistBtn = document.getElementById("delete-playlist-btn");
+const renamePlaylistBtn = document.getElementById("rename-playlist-btn");
 
 let onPlayCallback = null;
 
 toggleBtn.addEventListener("click", () => panel.classList.toggle("hidden"));
 closeBtn.addEventListener("click", () => panel.classList.add("hidden"));
 
+newPlaylistBtn.addEventListener("click", () => {
+  const name = prompt("Playlist name:");
+  if (!name || !name.trim()) return;
+  const id = store.createPlaylist(name.trim());
+  store.setActivePlaylist(id);
+  renderPlaylistSelector();
+  render();
+});
+
+deletePlaylistBtn.addEventListener("click", () => {
+  const id = store.getActivePlaylistId();
+  if (id === "queue") return;
+  const pl = store.getPlaylist(id);
+  if (!confirm(`Delete "${pl.name}"?`)) return;
+  store.deletePlaylist(id);
+  renderPlaylistSelector();
+  render();
+});
+
+renamePlaylistBtn.addEventListener("click", () => {
+  const id = store.getActivePlaylistId();
+  if (id === "queue") return;
+  const pl = store.getPlaylist(id);
+  const name = prompt("New name:", pl.name);
+  if (!name || !name.trim()) return;
+  store.renamePlaylist(id, name.trim());
+  renderPlaylistSelector();
+});
+
+playlistSelect.addEventListener("change", () => {
+  store.setActivePlaylist(playlistSelect.value);
+  updatePlaylistActions();
+  render();
+});
+
 export function initQueue({ onPlay }) {
   onPlayCallback = onPlay;
+  renderPlaylistSelector();
   render();
 }
 
 export function add(talk) {
-  if (talks.some((t) => t.id === talk.id)) return;
-  talks.push(talk);
-  save();
+  store.addTalk(store.getActivePlaylistId(), talk);
   render();
 }
 
+export function addToPlaylist(playlistId, talk) {
+  store.addTalk(playlistId, talk);
+  if (playlistId === store.getActivePlaylistId()) render();
+}
+
 export function remove(id) {
-  talks = talks.filter((t) => t.id !== id);
-  save();
+  store.removeTalk(store.getActivePlaylistId(), id);
   render();
 }
 
 export function next() {
-  if (talks.length === 0) return null;
-  const talk = talks.shift();
-  save();
+  const talk = store.next();
   render();
   return talk;
 }
 
 export function getAll() {
-  return [...talks];
+  return store.getAll(store.getActivePlaylistId());
 }
 
 export function findById(id) {
-  return talks.find((t) => t.id === id) || null;
+  return store.findById(store.getActivePlaylistId(), id);
 }
 
-function save() {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(talks));
+export function getPlaylists() {
+  return store.getPlaylists();
 }
 
-function loadQueue() {
-  try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
-  } catch {
-    return [];
+function renderPlaylistSelector() {
+  const playlists = store.getPlaylists();
+  const activeId = store.getActivePlaylistId();
+  playlistSelect.innerHTML = "";
+  for (const pl of playlists) {
+    const opt = document.createElement("option");
+    opt.value = pl.id;
+    opt.textContent = pl.name + (pl.talks.length > 0 ? ` (${pl.talks.length})` : "");
+    opt.selected = pl.id === activeId;
+    playlistSelect.appendChild(opt);
   }
+  updatePlaylistActions();
+  updateToggleCount();
+}
+
+function updatePlaylistActions() {
+  const isDefault = store.getActivePlaylistId() === "queue";
+  deletePlaylistBtn.hidden = isDefault;
+  renamePlaylistBtn.hidden = isDefault;
+}
+
+function updateToggleCount() {
+  const total = store.getPlaylists().reduce((sum, pl) => sum + pl.talks.length, 0);
+  countEl.textContent = String(total);
 }
 
 function render() {
-  countEl.textContent = String(talks.length);
+  const activeId = store.getActivePlaylistId();
+  const talks = store.getAll(activeId);
+  updateToggleCount();
+  renderPlaylistSelector();
 
   if (talks.length === 0) {
-    listEl.innerHTML = '<div class="empty-state">Queue is empty</div>';
+    listEl.innerHTML = '<div class="empty-state">Playlist is empty</div>';
     return;
   }
 
   listEl.innerHTML = "";
-  talks.forEach((talk, i) => {
+  talks.forEach((talk) => {
     const el = document.createElement("div");
     el.className = "queue-item";
     el.innerHTML = `

--- a/public/styles.css
+++ b/public/styles.css
@@ -355,6 +355,61 @@ header h1 {
   font-size: 1rem;
 }
 
+#playlist-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+#playlist-select {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  background: white;
+}
+
+#new-playlist-btn {
+  background: #2d5016;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+#new-playlist-btn:hover {
+  background: #3d6b20;
+}
+
+#rename-playlist-btn,
+#delete-playlist-btn {
+  background: none;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 5px 8px;
+  font-size: 0.78rem;
+  cursor: pointer;
+  white-space: nowrap;
+  color: #666;
+}
+
+#delete-playlist-btn:hover {
+  border-color: #c00;
+  color: #c00;
+}
+
+#rename-playlist-btn:hover {
+  border-color: #2d5016;
+  color: #2d5016;
+}
+
 #queue-close {
   background: none;
   border: none;

--- a/tests/playlist.test.ts
+++ b/tests/playlist.test.ts
@@ -1,0 +1,265 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPlaylistStore } from "../public/playlist.js";
+
+/** Minimal in-memory storage that mimics localStorage */
+function mockStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    getItem: (k: string) => data.get(k) ?? null,
+    setItem: (k: string, v: string) => { data.set(k, v); },
+    removeItem: (k: string) => { data.delete(k); },
+    clear: () => data.clear(),
+    get length() { return data.size; },
+    key: (i: number) => [...data.keys()][i] ?? null,
+  };
+}
+
+const talk1 = { id: 1, title: "Talk 1", teacher: "Teacher A", durationMinutes: 30, date: "2024-01-01", audioUrl: "/a/1" };
+const talk2 = { id: 2, title: "Talk 2", teacher: "Teacher B", durationMinutes: 45, date: "2024-01-02", audioUrl: "/a/2" };
+const talk3 = { id: 3, title: "Talk 3", teacher: "Teacher A", durationMinutes: 60, date: "2024-01-03", audioUrl: "/a/3" };
+
+// --- Default playlist (Queue) ---
+
+test("new store has a default Queue playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  const playlists = store.getPlaylists();
+  assert.equal(playlists.length, 1);
+  assert.equal(playlists[0].id, "queue");
+  assert.equal(playlists[0].name, "Queue");
+  assert.deepEqual(playlists[0].talks, []);
+});
+
+test("active playlist defaults to Queue", () => {
+  const store = createPlaylistStore(mockStorage());
+  assert.equal(store.getActivePlaylistId(), "queue");
+});
+
+// --- Adding talks ---
+
+test("add talk to default playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("queue", talk1);
+  const pl = store.getPlaylist("queue");
+  assert.equal(pl!.talks.length, 1);
+  assert.equal(pl!.talks[0].id, 1);
+});
+
+test("adding duplicate talk is ignored", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("queue", talk1);
+  store.addTalk("queue", talk1);
+  assert.equal(store.getPlaylist("queue")!.talks.length, 1);
+});
+
+test("add multiple talks", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("queue", talk1);
+  store.addTalk("queue", talk2);
+  assert.equal(store.getPlaylist("queue")!.talks.length, 2);
+});
+
+// --- Removing talks ---
+
+test("remove talk from playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("queue", talk1);
+  store.addTalk("queue", talk2);
+  store.removeTalk("queue", 1);
+  const pl = store.getPlaylist("queue")!;
+  assert.equal(pl.talks.length, 1);
+  assert.equal(pl.talks[0].id, 2);
+});
+
+test("remove non-existent talk is no-op", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("queue", talk1);
+  store.removeTalk("queue", 999);
+  assert.equal(store.getPlaylist("queue")!.talks.length, 1);
+});
+
+// --- next() ---
+
+test("next() returns and removes first talk from active playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("queue", talk1);
+  store.addTalk("queue", talk2);
+  const next = store.next();
+  assert.deepEqual(next, talk1);
+  assert.equal(store.getPlaylist("queue")!.talks.length, 1);
+});
+
+test("next() returns null on empty playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  assert.equal(store.next(), null);
+});
+
+// --- Creating playlists ---
+
+test("create a new playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  const id = store.createPlaylist("Favorites");
+  assert.ok(id);
+  assert.equal(store.getPlaylists().length, 2);
+  assert.equal(store.getPlaylist(id)!.name, "Favorites");
+  assert.deepEqual(store.getPlaylist(id)!.talks, []);
+});
+
+test("add talk to a custom playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  const id = store.createPlaylist("Metta");
+  store.addTalk(id, talk1);
+  store.addTalk(id, talk2);
+  assert.equal(store.getPlaylist(id)!.talks.length, 2);
+  // Queue should be unaffected
+  assert.equal(store.getPlaylist("queue")!.talks.length, 0);
+});
+
+// --- Renaming playlists ---
+
+test("rename a custom playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  const id = store.createPlaylist("Old Name");
+  store.renamePlaylist(id, "New Name");
+  assert.equal(store.getPlaylist(id)!.name, "New Name");
+});
+
+test("cannot rename the default Queue playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.renamePlaylist("queue", "My Queue");
+  assert.equal(store.getPlaylist("queue")!.name, "Queue");
+});
+
+// --- Deleting playlists ---
+
+test("delete a custom playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  const id = store.createPlaylist("Temp");
+  store.addTalk(id, talk1);
+  store.deletePlaylist(id);
+  assert.equal(store.getPlaylists().length, 1);
+  assert.equal(store.getPlaylist(id), null);
+});
+
+test("cannot delete the default Queue playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.deletePlaylist("queue");
+  assert.equal(store.getPlaylists().length, 1);
+  assert.equal(store.getPlaylist("queue")!.name, "Queue");
+});
+
+test("deleting active playlist resets active to queue", () => {
+  const store = createPlaylistStore(mockStorage());
+  const id = store.createPlaylist("Custom");
+  store.setActivePlaylist(id);
+  assert.equal(store.getActivePlaylistId(), id);
+  store.deletePlaylist(id);
+  assert.equal(store.getActivePlaylistId(), "queue");
+});
+
+// --- Active playlist ---
+
+test("set active playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  const id = store.createPlaylist("Custom");
+  store.setActivePlaylist(id);
+  assert.equal(store.getActivePlaylistId(), id);
+});
+
+test("next() uses active playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  const id = store.createPlaylist("Custom");
+  store.addTalk(id, talk3);
+  store.addTalk("queue", talk1);
+  store.setActivePlaylist(id);
+  const next = store.next();
+  assert.deepEqual(next, talk3);
+  // Queue untouched
+  assert.equal(store.getPlaylist("queue")!.talks.length, 1);
+});
+
+// --- Persistence ---
+
+test("state persists across store instances", () => {
+  const storage = mockStorage();
+  const store1 = createPlaylistStore(storage);
+  store1.addTalk("queue", talk1);
+  store1.addTalk("queue", talk2);
+  const id = store1.createPlaylist("Saved");
+  store1.addTalk(id, talk3);
+  store1.setActivePlaylist(id);
+
+  // New store instance reading from same storage
+  const store2 = createPlaylistStore(storage);
+  assert.equal(store2.getPlaylist("queue")!.talks.length, 2);
+  assert.equal(store2.getPlaylists().length, 2);
+  assert.equal(store2.getPlaylist(id)!.talks.length, 1);
+  assert.equal(store2.getActivePlaylistId(), id);
+});
+
+// --- Migration from old talk_queue ---
+
+test("migrates old talk_queue data into default Queue playlist", () => {
+  const storage = mockStorage();
+  // Simulate old format: just an array of talks under "talk_queue"
+  storage.setItem("talk_queue", JSON.stringify([talk1, talk2]));
+
+  const store = createPlaylistStore(storage);
+  const queue = store.getPlaylist("queue")!;
+  assert.equal(queue.talks.length, 2);
+  assert.equal(queue.talks[0].id, 1);
+  assert.equal(queue.talks[1].id, 2);
+  // Old key should be cleaned up
+  assert.equal(storage.getItem("talk_queue"), null);
+});
+
+test("migration does not happen if playlists already exist", () => {
+  const storage = mockStorage();
+  // Set up existing playlists
+  const existing = [{ id: "queue", name: "Queue", talks: [talk3] }];
+  storage.setItem("playlists", JSON.stringify(existing));
+  // Old key also present (shouldn't happen, but be safe)
+  storage.setItem("talk_queue", JSON.stringify([talk1, talk2]));
+
+  const store = createPlaylistStore(storage);
+  // Should use the playlists data, not migrate
+  assert.equal(store.getPlaylist("queue")!.talks.length, 1);
+  assert.equal(store.getPlaylist("queue")!.talks[0].id, 3);
+});
+
+// --- findById ---
+
+test("findById searches within a playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("queue", talk1);
+  store.addTalk("queue", talk2);
+  assert.deepEqual(store.findById("queue", 2), talk2);
+  assert.equal(store.findById("queue", 999), null);
+});
+
+// --- getAll convenience ---
+
+test("getAll returns talks from a playlist", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("queue", talk1);
+  store.addTalk("queue", talk2);
+  const all = store.getAll("queue");
+  assert.equal(all.length, 2);
+  // Should be a copy
+  all.push(talk3);
+  assert.equal(store.getAll("queue").length, 2);
+});
+
+// --- Edge cases ---
+
+test("adding to non-existent playlist is no-op", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.addTalk("nonexistent", talk1);
+  assert.equal(store.getPlaylists().length, 1);
+});
+
+test("setting active to non-existent playlist is no-op", () => {
+  const store = createPlaylistStore(mockStorage());
+  store.setActivePlaylist("nonexistent");
+  assert.equal(store.getActivePlaylistId(), "queue");
+});


### PR DESCRIPTION
- Create playlist.js: pure data layer with createPlaylistStore() factory, injectable storage for testability, migration from old talk_queue format
- 25 tests covering CRUD, active playlist switching, persistence, migration
- Update queue.js to use playlist store instead of raw localStorage
- Add playlist selector, create/rename/delete controls to queue panel UI
- Default "Queue" playlist preserved as non-deletable/non-renamable
