### PR TITLE
Replace dropdown playlist selector with mobile-friendly picker view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,14 +39,20 @@
 
   <div id="queue-panel" class="hidden">
     <div id="queue-header">
-      <div id="playlist-controls">
-        <select id="playlist-select"></select>
-        <button id="new-playlist-btn" title="New playlist">+</button>
-        <button id="rename-playlist-btn" title="Rename playlist" hidden>Rename</button>
-        <button id="delete-playlist-btn" title="Delete playlist" hidden>Delete</button>
-      </div>
+      <button id="playlist-switch-btn" title="Switch playlist">
+        <span id="playlist-active-name">Queue</span>
+        <span class="playlist-switch-arrow">&#9662;</span>
+      </button>
       <button id="queue-close">&times;</button>
     </div>
+
+    <!-- Playlist picker view -->
+    <div id="playlist-picker" class="hidden">
+      <div id="playlist-picker-list"></div>
+      <button id="new-playlist-btn">+ New Playlist</button>
+    </div>
+
+    <!-- Talk list view -->
     <div id="queue-list"></div>
   </div>
 

--- a/public/queue.js
+++ b/public/queue.js
@@ -7,54 +7,49 @@ const countEl = document.getElementById("queue-count");
 const panel = document.getElementById("queue-panel");
 const toggleBtn = document.getElementById("queue-btn");
 const closeBtn = document.getElementById("queue-close");
-const playlistSelect = document.getElementById("playlist-select");
+const switchBtn = document.getElementById("playlist-switch-btn");
+const activeNameEl = document.getElementById("playlist-active-name");
+const picker = document.getElementById("playlist-picker");
+const pickerList = document.getElementById("playlist-picker-list");
 const newPlaylistBtn = document.getElementById("new-playlist-btn");
-const deletePlaylistBtn = document.getElementById("delete-playlist-btn");
-const renamePlaylistBtn = document.getElementById("rename-playlist-btn");
 
 let onPlayCallback = null;
 
-toggleBtn.addEventListener("click", () => panel.classList.toggle("hidden"));
+toggleBtn.addEventListener("click", () => {
+  panel.classList.toggle("hidden");
+  // Always start on the talk list view, not the picker
+  picker.classList.add("hidden");
+  listEl.classList.remove("hidden");
+});
 closeBtn.addEventListener("click", () => panel.classList.add("hidden"));
+
+// Toggle between picker and talk list
+switchBtn.addEventListener("click", () => {
+  const showingPicker = !picker.classList.contains("hidden");
+  if (showingPicker) {
+    picker.classList.add("hidden");
+    listEl.classList.remove("hidden");
+  } else {
+    renderPicker();
+    picker.classList.remove("hidden");
+    listEl.classList.add("hidden");
+  }
+});
 
 newPlaylistBtn.addEventListener("click", () => {
   const name = prompt("Playlist name:");
   if (!name || !name.trim()) return;
   const id = store.createPlaylist(name.trim());
   store.setActivePlaylist(id);
-  renderPlaylistSelector();
-  render();
-});
-
-deletePlaylistBtn.addEventListener("click", () => {
-  const id = store.getActivePlaylistId();
-  if (id === "queue") return;
-  const pl = store.getPlaylist(id);
-  if (!confirm(`Delete "${pl.name}"?`)) return;
-  store.deletePlaylist(id);
-  renderPlaylistSelector();
-  render();
-});
-
-renamePlaylistBtn.addEventListener("click", () => {
-  const id = store.getActivePlaylistId();
-  if (id === "queue") return;
-  const pl = store.getPlaylist(id);
-  const name = prompt("New name:", pl.name);
-  if (!name || !name.trim()) return;
-  store.renamePlaylist(id, name.trim());
-  renderPlaylistSelector();
-});
-
-playlistSelect.addEventListener("change", () => {
-  store.setActivePlaylist(playlistSelect.value);
-  updatePlaylistActions();
+  picker.classList.add("hidden");
+  listEl.classList.remove("hidden");
+  updateHeader();
   render();
 });
 
 export function initQueue({ onPlay }) {
   onPlayCallback = onPlay;
-  renderPlaylistSelector();
+  updateHeader();
   render();
 }
 
@@ -91,25 +86,10 @@ export function getPlaylists() {
   return store.getPlaylists();
 }
 
-function renderPlaylistSelector() {
-  const playlists = store.getPlaylists();
-  const activeId = store.getActivePlaylistId();
-  playlistSelect.innerHTML = "";
-  for (const pl of playlists) {
-    const opt = document.createElement("option");
-    opt.value = pl.id;
-    opt.textContent = pl.name + (pl.talks.length > 0 ? ` (${pl.talks.length})` : "");
-    opt.selected = pl.id === activeId;
-    playlistSelect.appendChild(opt);
-  }
-  updatePlaylistActions();
+function updateHeader() {
+  const pl = store.getPlaylist(store.getActivePlaylistId());
+  activeNameEl.textContent = pl ? pl.name : "Queue";
   updateToggleCount();
-}
-
-function updatePlaylistActions() {
-  const isDefault = store.getActivePlaylistId() === "queue";
-  deletePlaylistBtn.hidden = isDefault;
-  renamePlaylistBtn.hidden = isDefault;
 }
 
 function updateToggleCount() {
@@ -117,11 +97,73 @@ function updateToggleCount() {
   countEl.textContent = String(total);
 }
 
+function renderPicker() {
+  const playlists = store.getPlaylists();
+  const activeId = store.getActivePlaylistId();
+  pickerList.innerHTML = "";
+
+  for (const pl of playlists) {
+    const el = document.createElement("div");
+    el.className = "playlist-picker-item" + (pl.id === activeId ? " active" : "");
+
+    const btn = document.createElement("button");
+    btn.className = "playlist-picker-btn";
+    btn.innerHTML = `
+      <span class="playlist-picker-name">${esc(pl.name)}</span>
+      <span class="playlist-picker-count">${pl.talks.length} talk${pl.talks.length !== 1 ? "s" : ""}</span>
+    `;
+    btn.addEventListener("click", () => {
+      store.setActivePlaylist(pl.id);
+      picker.classList.add("hidden");
+      listEl.classList.remove("hidden");
+      updateHeader();
+      render();
+    });
+    el.appendChild(btn);
+
+    // Actions for custom playlists (not queue)
+    if (pl.id !== "queue") {
+      const actions = document.createElement("div");
+      actions.className = "playlist-picker-actions";
+
+      const renameBtn = document.createElement("button");
+      renameBtn.className = "playlist-action-btn";
+      renameBtn.textContent = "Rename";
+      renameBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const name = prompt("New name:", pl.name);
+        if (!name || !name.trim()) return;
+        store.renamePlaylist(pl.id, name.trim());
+        updateHeader();
+        renderPicker();
+      });
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.className = "playlist-action-btn delete";
+      deleteBtn.textContent = "Delete";
+      deleteBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        if (!confirm(`Delete "${pl.name}"?`)) return;
+        store.deletePlaylist(pl.id);
+        updateHeader();
+        renderPicker();
+        render();
+      });
+
+      actions.appendChild(renameBtn);
+      actions.appendChild(deleteBtn);
+      el.appendChild(actions);
+    }
+
+    pickerList.appendChild(el);
+  }
+}
+
 function render() {
   const activeId = store.getActivePlaylistId();
   const talks = store.getAll(activeId);
   updateToggleCount();
-  renderPlaylistSelector();
+  updateHeader();
 
   if (talks.length === 0) {
     listEl.innerHTML = '<div class="empty-state">Playlist is empty</div>';

--- a/public/styles.css
+++ b/public/styles.css
@@ -351,63 +351,148 @@ header h1 {
   border-bottom: 1px solid #eee;
 }
 
-#queue-header h2 {
-  font-size: 1rem;
-}
-
-#playlist-controls {
+/* Playlist switch button in header */
+#playlist-switch-btn {
   display: flex;
   align-items: center;
   gap: 6px;
-  flex: 1;
-  min-width: 0;
-}
-
-#playlist-select {
-  flex: 1;
-  min-width: 0;
-  padding: 6px 8px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  font-size: 0.85rem;
-  background: white;
-}
-
-#new-playlist-btn {
-  background: #2d5016;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-#new-playlist-btn:hover {
-  background: #3d6b20;
-}
-
-#rename-playlist-btn,
-#delete-playlist-btn {
   background: none;
-  border: 1px solid #ccc;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #333;
+  min-width: 0;
+  flex: 1;
+}
+
+#playlist-switch-btn:hover {
+  background: #f5f5f5;
+}
+
+#playlist-active-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  text-align: left;
+}
+
+.playlist-switch-arrow {
+  font-size: 0.7rem;
+  color: #999;
+  flex-shrink: 0;
+}
+
+/* Playlist picker view */
+#playlist-picker {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#playlist-picker.hidden {
+  display: none;
+}
+
+.playlist-picker-item {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  transition: border-color 0.15s;
+}
+
+.playlist-picker-item.active {
+  border-color: #2d5016;
+  background: #f8faf6;
+}
+
+.playlist-picker-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 14px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 1rem;
+}
+
+.playlist-picker-btn:hover {
+  background: #f5f5f5;
+}
+
+.playlist-picker-item.active .playlist-picker-btn:hover {
+  background: #eef4ea;
+}
+
+.playlist-picker-name {
+  font-weight: 500;
+  color: #333;
+}
+
+.playlist-picker-item.active .playlist-picker-name {
+  color: #2d5016;
+  font-weight: 600;
+}
+
+.playlist-picker-count {
+  font-size: 0.8rem;
+  color: #999;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+.playlist-picker-actions {
+  display: flex;
+  gap: 4px;
+  padding: 0 12px 10px;
+}
+
+.playlist-action-btn {
+  padding: 5px 10px;
+  border: 1px solid #ddd;
   border-radius: 6px;
-  padding: 5px 8px;
+  background: white;
   font-size: 0.78rem;
   cursor: pointer;
-  white-space: nowrap;
   color: #666;
 }
 
-#delete-playlist-btn:hover {
+.playlist-action-btn:hover {
+  border-color: #2d5016;
+  color: #2d5016;
+}
+
+.playlist-action-btn.delete:hover {
   border-color: #c00;
   color: #c00;
 }
 
-#rename-playlist-btn:hover {
+#new-playlist-btn {
+  margin-top: 4px;
+  padding: 14px 16px;
+  background: white;
+  border: 2px dashed #ccc;
+  border-radius: 10px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  color: #666;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+#new-playlist-btn:hover {
   border-color: #2d5016;
   color: #2d5016;
+  background: #f8faf6;
 }
 
 #queue-close {
@@ -422,6 +507,10 @@ header h1 {
   flex: 1;
   overflow-y: auto;
   padding: 8px 16px;
+}
+
+#queue-list.hidden {
+  display: none;
 }
 
 .queue-item {


### PR DESCRIPTION
The <select> dropdown was hard to use on mobile. Replace with a two-view panel: tapping the playlist name in the header toggles a full-screen picker showing all playlists as large, tappable cards with talk counts. Active playlist is highlighted with a green border. Custom playlists show inline rename/delete actions.

https://claude.ai/code/session_018pauiQiENdjFBzRb8yXi2u