### PR TITLE
Switch retreat talks from broken RSS feed to HTML scraping

### DIFF
--- a/tests/dharmaseed.test.ts
+++ b/tests/dharmaseed.test.ts
@@ -62,94 +62,69 @@ test("searchTalks parses talk list HTML", async () => {
   }
 });
 
-test("fetchRetreatTalks parses RSS and removes duplicate talks", async () => {
-  const xml = `
-    <rss>
-      <channel>
-        <title>Weekend Retreat (Dharma Seed: Retreat talks)</title>
-        <item>
-          <link>https://dharmaseed.org/talks/900/</link>
-          <title>Jane Doe: First Talk</title>
-          <itunes:author>Jane Doe</itunes:author>
-          <itunes:duration>0:45:00</itunes:duration>
-          <pubDate>Tue, 14 Jan 2025 12:00:00 GMT</pubDate>
-          <enclosure url="https://dharmaseed.org//talks/900/file.mp3?rss=" />
-        </item>
-        <item>
-          <link>https://dharmaseed.org/talks/900/</link>
-          <title>Jane Doe: Duplicate Talk</title>
-          <itunes:author>Jane Doe</itunes:author>
-          <itunes:duration>0:45:00</itunes:duration>
-          <pubDate>Tue, 14 Jan 2025 12:00:00 GMT</pubDate>
-          <enclosure url="https://dharmaseed.org//talks/900/file.mp3?rss=" />
-        </item>
-      </channel>
-    </rss>
+test("fetchRetreatTalks parses HTML retreat page and extracts title", async () => {
+  const html = `
+    <h2>Weekend Retreat</h2>
+    <table width='100%'>
+      <a class="talkteacher" href="/talks/900">First Talk</a>
+      2025-01-14
+      <i>0:45:00</i>
+      <a class='talkteacher' href="/teacher/5">Jane Doe</a>
+      <a href="/talks/900/file.mp3">audio</a>
+    </table>
   `;
 
-  const restore = mockFetch(async () => new Response(xml, { status: 200 }));
+  let requestedUrl = "";
+  const restore = mockFetch(async (input) => {
+    requestedUrl = String(input);
+    return new Response(html, { status: 200 });
+  });
 
   try {
     const result = await fetchRetreatTalks(77, 1);
+    assert.equal(requestedUrl.includes("/retreats/77/"), true);
+    assert.equal(requestedUrl.includes("page=1"), true);
+    assert.equal(requestedUrl.includes("page_items=25"), true);
     assert.equal(result.retreatTitle, "Weekend Retreat");
+    assert.equal(result.hasMore, false);
     assert.equal(result.talks.length, 1);
     assert.equal(result.talks[0].title, "First Talk");
     assert.equal(result.talks[0].durationMinutes, 45);
     assert.equal(result.talks[0].date, "2025-01-14");
-    assert.equal(
-      result.talks[0].audioUrl,
-      "https://dharmaseed.org/talks/900/file.mp3"
-    );
+    assert.equal(result.talks[0].retreatId, 77);
+    assert.equal(result.talks[0].retreatTitle, "Weekend Retreat");
   } finally {
     restore();
   }
 });
 
-test("fetchRetreatTalks sorts talks by date descending", async () => {
-  const xml = `
-    <rss>
-      <channel>
-        <title>Meditation Retreat (Dharma Seed: Retreat talks)</title>
-        <item>
-          <link>https://dharmaseed.org/talks/101/</link>
-          <title>Teacher A: Middle Talk</title>
-          <itunes:author>Teacher A</itunes:author>
-          <itunes:duration>0:30:00</itunes:duration>
-          <pubDate>Wed, 15 Jan 2025 12:00:00 GMT</pubDate>
-          <enclosure url="https://dharmaseed.org/talks/101/file.mp3" />
-        </item>
-        <item>
-          <link>https://dharmaseed.org/talks/102/</link>
-          <title>Teacher A: Newest Talk</title>
-          <itunes:author>Teacher A</itunes:author>
-          <itunes:duration>0:45:00</itunes:duration>
-          <pubDate>Fri, 17 Jan 2025 12:00:00 GMT</pubDate>
-          <enclosure url="https://dharmaseed.org/talks/102/file.mp3" />
-        </item>
-        <item>
-          <link>https://dharmaseed.org/talks/103/</link>
-          <title>Teacher A: Oldest Talk</title>
-          <itunes:author>Teacher A</itunes:author>
-          <itunes:duration>1:00:00</itunes:duration>
-          <pubDate>Mon, 13 Jan 2025 12:00:00 GMT</pubDate>
-          <enclosure url="https://dharmaseed.org/talks/103/file.mp3" />
-        </item>
-      </channel>
-    </rss>
+test("fetchRetreatTalks paginates using HTML page", async () => {
+  const html = `
+    <h2>Big Retreat</h2>
+    <table width='100%'>
+      <a class="talkteacher" href="/talks/101">Talk One</a>
+      2025-01-15
+      <i>0:30:00</i>
+      <a class='talkteacher' href="/teacher/1">Teacher A</a>
+      <a href="/talks/101/file.mp3">audio</a>
+    </table>
+    <a class="next">next</a>
   `;
 
-  const restore = mockFetch(async () => new Response(xml, { status: 200 }));
+  let requestedUrl = "";
+  const restore = mockFetch(async (input) => {
+    requestedUrl = String(input);
+    return new Response(html, { status: 200 });
+  });
 
   try {
-    const result = await fetchRetreatTalks(55, 1);
-    assert.equal(result.talks.length, 3);
-    // Should be sorted newest first
-    assert.equal(result.talks[0].date, "2025-01-17");
-    assert.equal(result.talks[0].title, "Newest Talk");
-    assert.equal(result.talks[1].date, "2025-01-15");
-    assert.equal(result.talks[1].title, "Middle Talk");
-    assert.equal(result.talks[2].date, "2025-01-13");
-    assert.equal(result.talks[2].title, "Oldest Talk");
+    const result = await fetchRetreatTalks(55, 2);
+    assert.equal(requestedUrl.includes("page=2"), true);
+    assert.equal(result.hasMore, true);
+    assert.equal(result.page, 2);
+    assert.equal(result.talks.length, 1);
+    assert.equal(result.talks[0].retreatId, 55);
+    assert.equal(result.talks[0].retreatTitle, "Big Retreat");
   } finally {
     restore();
   }

--- a/worker/dharmaseed.ts
+++ b/worker/dharmaseed.ts
@@ -241,84 +241,27 @@ export function parseTeacherRetreats(html: string): Retreat[] {
 
 export async function fetchRetreatTalks(
   retreatId: number,
-  _page: number
+  page: number
 ): Promise<SearchResponse & { retreatTitle?: string }> {
-  const url = `https://dharmaseed.org/feeds/retreat/${retreatId}/`;
+  const url = `${BASE}/retreats/${retreatId}/?sort=-rec_date&page=${page}&page_items=25`;
   const res = await fetch(url, {
     headers: { "User-Agent": "DharmaSeedPlayer/1.0" },
   });
-  if (!res.ok) throw new Error(`Retreat RSS failed: ${res.status}`);
-  const xml = await res.text();
-  return parseRetreatRSS(xml, retreatId);
-}
+  if (!res.ok) throw new Error(`Retreat page failed: ${res.status}`);
+  const html = await res.text();
+  const result = parseTalkList(html, page);
 
-function parseRetreatRSS(
-  xml: string,
-  retreatId: number
-): SearchResponse & { retreatTitle?: string } {
-  // Extract retreat title from channel <title>, strip "(Dharma Seed: Retreat talks)" suffix
-  const channelTitleMatch = xml.match(/<channel>[\s\S]*?<title>([^<]+)<\/title>/);
-  let retreatTitle = channelTitleMatch ? channelTitleMatch[1].trim() : undefined;
-  if (retreatTitle) {
-    retreatTitle = retreatTitle.replace(/\s*\(Dharma Seed:.*?\)\s*$/, "").trim();
+  // Extract retreat title from <h2> on the page
+  const h2Match = html.match(/<h2>([^<]+)<\/h2>/);
+  const retreatTitle = h2Match ? decodeEntities(h2Match[1].trim()) : undefined;
+
+  // Tag each talk with retreat info
+  for (const talk of result.talks) {
+    talk.retreatId = retreatId;
+    if (retreatTitle) talk.retreatTitle = retreatTitle;
   }
 
-  const items = xml.split(/<item>/);
-  items.shift(); // discard everything before first <item>
-
-  const seen = new Set<number>();
-  const talks: Talk[] = [];
-
-  for (const item of items) {
-    const link = rssText(item, "link");
-    const idMatch = link.match(/\/talks\/(\d+)/);
-    if (!idMatch) continue;
-    const id = parseInt(idMatch[1], 10);
-
-    if (seen.has(id)) continue;
-    seen.add(id);
-
-    const teacher = rssText(item, "itunes:author");
-
-    let title = rssText(item, "title");
-    const colonIdx = title.indexOf(": ");
-    if (colonIdx > 0 && teacher && title.slice(0, colonIdx).includes(teacher)) {
-      title = title.slice(colonIdx + 2);
-    }
-
-    const durationStr = rssText(item, "itunes:duration");
-    const durationMinutes = durationStr ? parseDuration(durationStr) : 0;
-
-    const pubDate = rssText(item, "pubDate");
-    const date = parseRSSDate(pubDate);
-
-    let audioUrl = rssAttr(item, "enclosure", "url");
-    audioUrl = audioUrl.replace("//talks/", "/talks/").replace(/\?rss=$/, "");
-
-    talks.push({ id, title, teacher, durationMinutes, date, audioUrl, retreatId, retreatTitle });
-  }
-
-  talks.sort((a, b) => (b.date || "").localeCompare(a.date || ""));
-
-  return { talks, page: 1, hasMore: false, retreatTitle };
-}
-
-function rssText(xml: string, tag: string): string {
-  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, "i");
-  const m = xml.match(re);
-  return m ? m[1].trim() : "";
-}
-
-function rssAttr(xml: string, tag: string, attr: string): string {
-  const re = new RegExp(`<${tag}[^>]*${attr}="([^"]*)"`, "i");
-  const m = xml.match(re);
-  return m ? m[1] : "";
-}
-
-function parseRSSDate(rfc2822: string): string {
-  const d = new Date(rfc2822);
-  if (isNaN(d.getTime())) return "";
-  return d.toISOString().slice(0, 10);
+  return { ...result, retreatTitle };
 }
 
 export async function fetchTalkDetail(


### PR DESCRIPTION
The RSS feed at /feeds/retreat/{id}/ returns only a tiny subset of talks (e.g. 9 out of 700+ for large retreats). The dharmaseed retreat HTML page at /retreats/{id}/ uses the exact same format as teacher and search pages, with proper pagination via page/page_items params.

Switch fetchRetreatTalks to scrape the HTML page using the existing parseTalkList function. This gives us:
- All talks (not just the RSS subset)
- Proper pagination with hasMore detection
- Consistent approach across search, teacher, and retreat views

Remove dead RSS parsing code (parseRetreatRSS, rssText, rssAttr, parseRSSDate) and update tests to use HTML fixtures.

https://claude.ai/code/session_01F2cXEEoq2adyk2AazNvkNg