### PR TITLE
Sort retreat talks oldest-first so the beginning of the retreat appears at the top

### DIFF
--- a/worker/dharmaseed.ts
+++ b/worker/dharmaseed.ts
@@ -243,7 +243,7 @@ export async function fetchRetreatTalks(
   retreatId: number,
   page: number
 ): Promise<SearchResponse & { retreatTitle?: string }> {
-  const url = `${BASE}/retreats/${retreatId}/?sort=-rec_date&page=${page}&page_items=25`;
+  const url = `${BASE}/retreats/${retreatId}/?sort=rec_date&page=${page}&page_items=25`;
   const res = await fetch(url, {
     headers: { "User-Agent": "DharmaSeedPlayer/1.0" },
   });


### PR DESCRIPTION
Changed the Dharma Seed retreat page sort parameter from -rec_date (descending)
to rec_date (ascending) so talks are listed chronologically from the start of
the retreat.

https://claude.ai/code/session_01FHwKC1AmZbL8fD7UqKkdqY